### PR TITLE
Cleanup and bug fix

### DIFF
--- a/why.js
+++ b/why.js
@@ -9,26 +9,27 @@ function extLog(logLine)
 {
 	chrome.extension.getBackgroundPage().console.log(logLine);
 }
+
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	var url = changeInfo.url;
 	extLog("here");
 	if(url)
-	{	
+	{
 		urlChanges++;
 		if (urlChanges >= retriggerThreshold) answeredTabs.pop(tabId);
 		extLog(badurls.length);
 		for (i = 0; i < badurls.length; i++)
-		{			
+		{
 			if (url.indexOf(badurls[i]) >= 0)
-			{				
+			{
 				extLog(urlChanges);
-				if (answeredTabs.indexOf(tabId) == -1) 
-					{
-						onWhyTab(tabId);
-					}
+				if (answeredTabs.indexOf(tabId) == -1)
+				{
+					onWhyTab(tabId);
+				}
 			}
-		}		
-	} 
+		}
+	}
 });
 
 function onWhyTab(tabId){
@@ -44,8 +45,7 @@ function onWhyTab(tabId){
 		console.log("Closing tab");
 	}
 	else
-	{ 
-		
+	{
 		answeredTabs.push(tabId);
 		reasons.push(reason);
 		extLog(answeredTabs);
@@ -58,5 +58,6 @@ function isValidReason(reason)
 {
 	if (reason == null || reason =="") return false;
 	if (reason.length < minReasonLength) return false;
+
 	return true;
 }

--- a/why.js
+++ b/why.js
@@ -5,12 +5,20 @@ var reasons = [];
 var badurls = ["facebook","reddit"];
 const minReasonLength = 5;
 
+// Some links might include redirects, which triggers the event twice. This prevents the two unncessary calls.
+var tabsBeingProcessed = [];
+
 function extLog(logLine)
 {
 	chrome.extension.getBackgroundPage().console.log(logLine);
 }
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
+	if (tabsBeingProcessed.indexOf(tabId) != -1)
+		return;
+
+	tabsBeingProcessed.push(tabId);
+
 	var url = changeInfo.url;
 	extLog("here");
 	if(url)
@@ -30,6 +38,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 			}
 		}
 	}
+
+	tabsBeingProcessed.pop(tabId);
 });
 
 function onWhyTab(tabId){


### PR DESCRIPTION
Bug is as follows:

Say you find yourself in a page with a shortened link that includes the word `reddit` or any other forbidden word. You then click it and find yourself following the nick, which triggers the event. It then actually loads http://reddit.com and it triggers the event again since you haven't had time to submit an excuse.

If you fail to provide an excuse for either of those dialogues, the tab will close, which isn't exactly the expected behaviour.

Easiest way to reproduce this is to Google `redit` and then clicking the first link. Google actually provides a redirection link. 

This patch just prevents the same time from being processed at the same time.
